### PR TITLE
Add GitHub Actions workflow for tagging releases

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,20 @@
+name: Tag from package.json version
+
+on:
+  push:
+    branches:
+      - main 
+
+jobs:
+  create_tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Get version from package.json and create tag
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(grep -oP '(?<="version": ")[^"]*' package.json)
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push origin "v$VERSION"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "youtube-live-chat-fullscreen",
   "private": true,
-  "version": "2.0.26",
+  "version": "2.0.27",
   "type": "module",
   "scripts": {
     "dev": "run-s clean && vite",


### PR DESCRIPTION
Introduce a workflow that automatically creates and pushes tags based on the version specified in package.json upon pushing to the main branch.