### PR TITLE
fix(ci): validate release version and avoid shell interpolation injection

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,10 @@ jobs:
         run: |
           git fetch --tags
           VERSION=$(grep -oP '(?<="version": ")[^"]*' package.json)
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid package version: $VERSION"
+            exit 1
+          fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           if git rev-parse "refs/tags/v$VERSION" >/dev/null 2>&1; then
             echo "Tag v$VERSION already exists."
@@ -65,20 +69,8 @@ jobs:
             .output/*-chrome.zip \
             .output/*-firefox.zip
       - name: Submit to stores
-        run: |
-          CHROME_ZIP=".output/youtube-live-chat-fullscreen-${{ needs.create_tag.outputs.version }}-chrome.zip"
-          FIREFOX_ZIP=".output/youtube-live-chat-fullscreen-${{ needs.create_tag.outputs.version }}-firefox.zip"
-          SOURCES_ZIP=".output/youtube-live-chat-fullscreen-${{ needs.create_tag.outputs.version }}-sources.zip"
-
-          yarn submit:chrome:v2 -- \
-            --zip "$CHROME_ZIP" \
-            --expected-version "${{ needs.create_tag.outputs.version }}"
-
-          node ./node_modules/publish-browser-extension/bin/publish-extension.mjs \
-            --firefox-extension-id "youtube-live-chat-fullscreen" \
-            --firefox-zip "$FIREFOX_ZIP" \
-            --firefox-sources-zip "$SOURCES_ZIP"
         env:
+          RELEASE_VERSION: ${{ needs.create_tag.outputs.version }}
           CHROME_EXTENSION_ID: ${{ secrets.CHROME_EXTENSION_ID }}
           CHROME_PUBLISHER_ID: ${{ secrets.CHROME_PUBLISHER_ID }}
           CHROME_CLIENT_ID: ${{ secrets.CHROME_CLIENT_ID }}
@@ -86,3 +78,16 @@ jobs:
           CHROME_REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}
           FIREFOX_JWT_ISSUER: ${{ secrets.FIREFOX_JWT_ISSUER }}
           FIREFOX_JWT_SECRET: ${{ secrets.FIREFOX_JWT_SECRET }}
+        run: |
+          CHROME_ZIP=".output/youtube-live-chat-fullscreen-$RELEASE_VERSION-chrome.zip"
+          FIREFOX_ZIP=".output/youtube-live-chat-fullscreen-$RELEASE_VERSION-firefox.zip"
+          SOURCES_ZIP=".output/youtube-live-chat-fullscreen-$RELEASE_VERSION-sources.zip"
+
+          yarn submit:chrome:v2 -- \
+            --zip "$CHROME_ZIP" \
+            --expected-version "$RELEASE_VERSION"
+
+          node ./node_modules/publish-browser-extension/bin/publish-extension.mjs \
+            --firefox-extension-id "youtube-live-chat-fullscreen" \
+            --firefox-zip "$FIREFOX_ZIP" \
+            --firefox-sources-zip "$SOURCES_ZIP"


### PR DESCRIPTION
### Motivation
- Close a command-injection vector where the workflow extracted `version` from `package.json` and exported it without validation, then interpolated it directly into a secret-bearing shell `run` block. 

### Description
- Add a strict SemVer-like allowlist check in the `create_tag` step so `VERSION` is validated before writing to `GITHUB_OUTPUT` in ` .github/workflows/cd.yml`.
- Stop inserting `${{ needs.create_tag.outputs.version }}` directly into shell source in the `Submit to stores` step and instead expose the value via an `env` variable `RELEASE_VERSION`.
- Replace inline `${{ ... }}` usages in paths and arguments with quoted shell variable references like `$RELEASE_VERSION` so the release version cannot introduce shell metacharacters.
- Keep existing release/tagging behavior unchanged except for failing fast on invalid version formats.

### Testing
- Inspected the updated workflow file with `sed`/`nl` to verify the validation and `env`-passing changes were applied to ` .github/workflows/cd.yml`, which succeeded.
- Verified the repository pre-commit checks ran (hook output reported no files for inspection) and the file diff shows only the intended changes, which succeeded.
- Confirmed the new validation and substitutions are present in the committed diff and that the `Submit to stores` step now uses `RELEASE_VERSION` instead of direct expression interpolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80d245944832ea7ec7e920aedd882)