### PR TITLE
Improve Opera chat compatibility and prepare v2.3.15

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -63,7 +63,12 @@ body:
     id: evidence
     attributes:
       label: Screenshots, recording, or additional context
-      description: Drag files here. Include a public YouTube URL only when it is safe to share.
+      description: Drag files here or paste the sanitized diagnostic report. Include a public YouTube URL only when it is safe to share.
+  - type: textarea
+    id: isolation
+    attributes:
+      label: Browser isolation result
+      description: For Opera or another browser-specific failure, confirm the extension is enabled, has access to youtube.com, and note whether the same steps fail in a profile with only YLC enabled.
   - type: checkboxes
     id: checks
     attributes:

--- a/docs/store-listing/pt_BR.md
+++ b/docs/store-listing/pt_BR.md
@@ -17,6 +17,8 @@ Como usar:
 3. Entre em tela cheia — ative o botão no canto inferior direito.
 4. Arraste, redimensione e deixe do seu jeito.
 
+No Opera, se o botão não aparecer, abra `opera://extensions`, confirme que a extensão está ativada e que ela tem acesso ao `youtube.com`. Depois, recarregue uma transmissão ao vivo ou um arquivo com replay de chat e entre em tela cheia. O botão só aparece quando o chat está disponível para o vídeo.
+
 Perguntas, ideias ou bugs? Adoraríamos ouvir você no GitHub.
 
 Código-fonte: https://github.com/daichan132/Youtube-Live-Chat-Fullscreen

--- a/docs/verification-browser.md
+++ b/docs/verification-browser.md
@@ -46,6 +46,18 @@ yarn verify:chrome --setup-extension --port 9336 --url "https://www.youtube.com/
 
 Computer Use を使う場合の対象アプリ名は `Google Chrome` だが、同じアプリ名の普段使い Chrome と混ざりやすい。操作前に `verify:chrome` の出力にある `profileDir` と、表示中の URL が検証対象であることを確認する。
 
+## Opera など Chromium 系ブラウザの fixture 検証
+
+Chrome 以外の Chromium 系ブラウザで content script、fullscreen、チャット切替を確認するときは、testing build と専用の一時プロファイルを使う。
+
+```bash
+yarn build:e2e
+YLC_BROWSER_EXECUTABLE_PATH="/path/to/browser" YLC_E2E_HEADED=1 \
+  yarn playwright test --project=fixture e2e/scenarios/live/spaNavigation.fixture.spec.ts
+```
+
+`YLC_BROWSER_EXECUTABLE_PATH` 指定時は、対象ブラウザ本来の User-Agent を維持し、Playwright 同梱 Chromium 用の `channel` と Chrome User-Agent override を適用しない。通常プロファイルや既存の拡張状態は再利用しない。
+
 ## 状態確認
 
 別ターミナルで次を実行する。

--- a/e2e/support/extension/extensionContext.ts
+++ b/e2e/support/extension/extensionContext.ts
@@ -8,25 +8,35 @@ import { type BrowserContext, chromium, type Page, type Worker } from '@playwrig
 
 const extensionOutputPath = path.resolve(E2E_EXTENSION_OUTPUT_DIR)
 const EXTENSION_BOOT_TIMEOUT_MS = 45000
-let bundledChromiumVersion: string | null = null
+let resolvedBrowserVersion: { executablePath: string; version: string } | null = null
 
 export const extensionUsesServiceWorker = () => {
   const manifest = JSON.parse(readFileSync(path.join(extensionOutputPath, 'manifest.json'), 'utf8'))
   return typeof manifest.background?.service_worker === 'string'
 }
 
-const resolveBundledChromiumVersion = () => {
-  if (bundledChromiumVersion) return bundledChromiumVersion
-  const versionOutput = execFileSync(chromium.executablePath(), ['--version'], { encoding: 'utf8' })
+const resolveBrowserVersion = (executablePath: string) => {
+  if (resolvedBrowserVersion?.executablePath === executablePath) return resolvedBrowserVersion.version
+  const versionOutput = execFileSync(executablePath, ['--version'], { encoding: 'utf8' })
   const version = versionOutput.match(/\d+(?:\.\d+){3}/)?.[0]
-  if (!version) throw new Error(`Could not resolve bundled Chromium version from: ${versionOutput.trim()}`)
-  bundledChromiumVersion = version
+  if (!version) throw new Error(`Could not resolve browser version from: ${versionOutput.trim()}`)
+  resolvedBrowserVersion = { executablePath, version }
   return version
 }
 
 export const launchExtensionContext = async (userDataDir: string) => {
+  const customExecutablePath = process.env.YLC_BROWSER_EXECUTABLE_PATH?.trim()
+  const executablePath = customExecutablePath || chromium.executablePath()
+  const launchMode = resolveExtensionLaunchMode(process.env, {
+    browserVersion: resolveBrowserVersion(executablePath),
+  })
+  if (customExecutablePath) {
+    delete launchMode.channel
+    delete launchMode.userAgent
+  }
   const context = await chromium.launchPersistentContext(userDataDir, {
-    ...resolveExtensionLaunchMode(process.env, { browserVersion: resolveBundledChromiumVersion() }),
+    ...launchMode,
+    ...(customExecutablePath ? { executablePath } : {}),
     ignoreDefaultArgs: ['--disable-extensions'],
     args: [`--disable-extensions-except=${extensionOutputPath}`, `--load-extension=${extensionOutputPath}`, '--mute-audio'],
   })

--- a/entrypoints/content/chat/shared/iframeDom.spec.ts
+++ b/entrypoints/content/chat/shared/iframeDom.spec.ts
@@ -4,6 +4,7 @@ import {
   getLiveChatIframes,
   isChatHostForCurrentVideo,
   isIframeForCurrentVideo,
+  isReplayChatIframe,
   markChatIframeObservedForCurrentVideo,
 } from './iframeDom'
 
@@ -46,6 +47,37 @@ describe('isIframeForCurrentVideo', () => {
     markChatIframeObservedForCurrentVideo(iframe, 'current-video')
 
     expect(isIframeForCurrentVideo(iframe, 'current-video')).toBe(true)
+  })
+
+  it('retains replay identity when Opera blanks the observed native iframe during fullscreen', () => {
+    createWatchFlexy('current-video')
+    const host = document.createElement('ytd-live-chat-frame')
+    const iframe = document.createElement('iframe')
+    iframe.src = 'https://www.youtube.com/live_chat_replay?v=current-video'
+    host.appendChild(iframe)
+    document.body.appendChild(host)
+    markChatIframeObservedForCurrentVideo(iframe, 'current-video')
+
+    iframe.removeAttribute('src')
+
+    expect(isIframeForCurrentVideo(iframe, 'current-video')).toBe(true)
+    expect(isReplayChatIframe(iframe)).toBe(true)
+  })
+
+  it('carries observed replay identity to a blank replacement iframe in the same host', () => {
+    createWatchFlexy('current-video')
+    const host = document.createElement('ytd-live-chat-frame')
+    const iframe = document.createElement('iframe')
+    iframe.src = 'https://www.youtube.com/live_chat_replay?v=current-video'
+    host.appendChild(iframe)
+    document.body.appendChild(host)
+    markChatIframeObservedForCurrentVideo(iframe, 'current-video')
+
+    const replacement = document.createElement('iframe')
+    iframe.replaceWith(replacement)
+
+    expect(isIframeForCurrentVideo(replacement, 'current-video')).toBe(true)
+    expect(isReplayChatIframe(replacement)).toBe(true)
   })
 
   it('rejects unobserved continuation-only iframe URLs even when page DOM points at the current video', () => {

--- a/entrypoints/content/chat/shared/iframeDom.spec.ts
+++ b/entrypoints/content/chat/shared/iframeDom.spec.ts
@@ -4,6 +4,7 @@ import {
   getLiveChatIframes,
   isChatHostForCurrentVideo,
   isIframeForCurrentVideo,
+  isLiveChatIframe,
   isReplayChatIframe,
   markChatIframeObservedForCurrentVideo,
 } from './iframeDom'
@@ -78,6 +79,20 @@ describe('isIframeForCurrentVideo', () => {
 
     expect(isIframeForCurrentVideo(replacement, 'current-video')).toBe(true)
     expect(isReplayChatIframe(replacement)).toBe(true)
+  })
+
+  it('does not retain live identity after YouTube blanks an observed native iframe', () => {
+    createWatchFlexy('current-video')
+    const host = document.createElement('ytd-live-chat-frame')
+    const iframe = document.createElement('iframe')
+    iframe.src = 'https://www.youtube.com/live_chat?v=current-video'
+    host.appendChild(iframe)
+    document.body.appendChild(host)
+    markChatIframeObservedForCurrentVideo(iframe, 'current-video')
+
+    iframe.removeAttribute('src')
+
+    expect(isLiveChatIframe(iframe)).toBe(false)
   })
 
   it('rejects unobserved continuation-only iframe URLs even when page DOM points at the current video', () => {

--- a/entrypoints/content/chat/shared/iframeDom.ts
+++ b/entrypoints/content/chat/shared/iframeDom.ts
@@ -6,6 +6,8 @@ export const YLC_CHAT_ATTR = 'data-ylc-chat'
 export const YLC_SOURCE_ATTR = 'data-ylc-source'
 export const YLC_SOURCE_LIVE = 'live_direct'
 export const YLC_OBSERVED_VIDEO_ATTR = 'data-ylc-observed-video-id'
+const YLC_OBSERVED_MODE_ATTR = 'data-ylc-observed-chat-mode'
+type ObservedChatMode = 'live' | 'archive'
 
 const getIframeHrefFromSrc = (iframe: HTMLIFrameElement) => iframe.getAttribute('src') ?? iframe.src ?? ''
 
@@ -63,6 +65,10 @@ const getDeclaredIframeVideoId = (iframe: HTMLIFrameElement) => {
 }
 
 const getObservedVideoId = (element: Element | null | undefined) => element?.getAttribute(YLC_OBSERVED_VIDEO_ATTR) ?? null
+const getObservedChatMode = (element: Element | null | undefined): ObservedChatMode | null => {
+  const mode = element?.getAttribute(YLC_OBSERVED_MODE_ATTR)
+  return mode === 'live' || mode === 'archive' ? mode : null
+}
 
 const markObservedElementForCurrentVideo = (element: Element | null | undefined, currentVideoId: string | null) => {
   if (!element || !currentVideoId || !hasCurrentPageVideoMarker(currentVideoId)) return false
@@ -73,10 +79,14 @@ const markObservedElementForCurrentVideo = (element: Element | null | undefined,
 }
 
 export const markChatIframeObservedForCurrentVideo = (iframe: HTMLIFrameElement, currentVideoId = getCurrentYouTubeVideoId()) => {
-  if (getDeclaredIframeVideoId(iframe)) return
-  if (!isReplayChatIframe(iframe) && !isLiveChatIframe(iframe)) return
+  const mode: ObservedChatMode | null = isReplayChatIframe(iframe) ? 'archive' : isLiveChatIframe(iframe) ? 'live' : null
+  if (!mode) return
+  const declaredVideoId = getDeclaredIframeVideoId(iframe)
+  if (declaredVideoId && declaredVideoId !== currentVideoId) return
   if (!markObservedElementForCurrentVideo(iframe, currentVideoId)) return
-  markObservedElementForCurrentVideo(getChatHost(iframe), currentVideoId)
+  iframe.setAttribute(YLC_OBSERVED_MODE_ATTR, mode)
+  const host = getChatHost(iframe)
+  if (markObservedElementForCurrentVideo(host, currentVideoId)) host?.setAttribute(YLC_OBSERVED_MODE_ATTR, mode)
 }
 
 export const isChatHostForCurrentVideo = (host: HTMLElement | null | undefined) => {
@@ -126,7 +136,7 @@ export const isReplayChatIframe = (iframe: HTMLIFrameElement) => {
   if (hasReplayPath(docHref)) return true
 
   const srcHref = getIframeHrefFromSrc(iframe)
-  return hasReplayPath(srcHref)
+  return hasReplayPath(srcHref) || getObservedChatMode(iframe) === 'archive' || getObservedChatMode(getChatHost(iframe)) === 'archive'
 }
 
 export const isLiveChatIframe = (iframe: HTMLIFrameElement | null | undefined) => {
@@ -139,9 +149,9 @@ export const isLiveChatIframe = (iframe: HTMLIFrameElement | null | undefined) =
   }
 
   const srcHref = getIframeHrefFromSrc(iframe)
-  if (!srcHref) return false
+  if (!srcHref) return getObservedChatMode(iframe) === 'live' || getObservedChatMode(getChatHost(iframe)) === 'live'
   if (hasReplayPath(srcHref)) return false
-  return hasLivePath(srcHref)
+  return hasLivePath(srcHref) || getObservedChatMode(iframe) === 'live' || getObservedChatMode(getChatHost(iframe)) === 'live'
 }
 
 export const getIframeVideoId = (iframe: HTMLIFrameElement) => {

--- a/entrypoints/content/chat/shared/iframeDom.ts
+++ b/entrypoints/content/chat/shared/iframeDom.ts
@@ -7,7 +7,6 @@ export const YLC_SOURCE_ATTR = 'data-ylc-source'
 export const YLC_SOURCE_LIVE = 'live_direct'
 export const YLC_OBSERVED_VIDEO_ATTR = 'data-ylc-observed-video-id'
 const YLC_OBSERVED_MODE_ATTR = 'data-ylc-observed-chat-mode'
-type ObservedChatMode = 'live' | 'archive'
 
 const getIframeHrefFromSrc = (iframe: HTMLIFrameElement) => iframe.getAttribute('src') ?? iframe.src ?? ''
 
@@ -65,10 +64,7 @@ const getDeclaredIframeVideoId = (iframe: HTMLIFrameElement) => {
 }
 
 const getObservedVideoId = (element: Element | null | undefined) => element?.getAttribute(YLC_OBSERVED_VIDEO_ATTR) ?? null
-const getObservedChatMode = (element: Element | null | undefined): ObservedChatMode | null => {
-  const mode = element?.getAttribute(YLC_OBSERVED_MODE_ATTR)
-  return mode === 'live' || mode === 'archive' ? mode : null
-}
+const hasObservedArchiveMode = (element: Element | null | undefined) => element?.getAttribute(YLC_OBSERVED_MODE_ATTR) === 'archive'
 
 const markObservedElementForCurrentVideo = (element: Element | null | undefined, currentVideoId: string | null) => {
   if (!element || !currentVideoId || !hasCurrentPageVideoMarker(currentVideoId)) return false
@@ -79,14 +75,14 @@ const markObservedElementForCurrentVideo = (element: Element | null | undefined,
 }
 
 export const markChatIframeObservedForCurrentVideo = (iframe: HTMLIFrameElement, currentVideoId = getCurrentYouTubeVideoId()) => {
-  const mode: ObservedChatMode | null = isReplayChatIframe(iframe) ? 'archive' : isLiveChatIframe(iframe) ? 'live' : null
-  if (!mode) return
+  const isReplay = isReplayChatIframe(iframe)
+  if (!isReplay && !isLiveChatIframe(iframe)) return
   const declaredVideoId = getDeclaredIframeVideoId(iframe)
   if (declaredVideoId && declaredVideoId !== currentVideoId) return
   if (!markObservedElementForCurrentVideo(iframe, currentVideoId)) return
-  iframe.setAttribute(YLC_OBSERVED_MODE_ATTR, mode)
+  if (isReplay) iframe.setAttribute(YLC_OBSERVED_MODE_ATTR, 'archive')
   const host = getChatHost(iframe)
-  if (markObservedElementForCurrentVideo(host, currentVideoId)) host?.setAttribute(YLC_OBSERVED_MODE_ATTR, mode)
+  if (markObservedElementForCurrentVideo(host, currentVideoId) && isReplay) host?.setAttribute(YLC_OBSERVED_MODE_ATTR, 'archive')
 }
 
 export const isChatHostForCurrentVideo = (host: HTMLElement | null | undefined) => {
@@ -136,7 +132,7 @@ export const isReplayChatIframe = (iframe: HTMLIFrameElement) => {
   if (hasReplayPath(docHref)) return true
 
   const srcHref = getIframeHrefFromSrc(iframe)
-  return hasReplayPath(srcHref) || getObservedChatMode(iframe) === 'archive' || getObservedChatMode(getChatHost(iframe)) === 'archive'
+  return hasReplayPath(srcHref) || hasObservedArchiveMode(iframe) || hasObservedArchiveMode(getChatHost(iframe))
 }
 
 export const isLiveChatIframe = (iframe: HTMLIFrameElement | null | undefined) => {
@@ -149,9 +145,9 @@ export const isLiveChatIframe = (iframe: HTMLIFrameElement | null | undefined) =
   }
 
   const srcHref = getIframeHrefFromSrc(iframe)
-  if (!srcHref) return getObservedChatMode(iframe) === 'live' || getObservedChatMode(getChatHost(iframe)) === 'live'
+  if (!srcHref) return false
   if (hasReplayPath(srcHref)) return false
-  return hasLivePath(srcHref) || getObservedChatMode(iframe) === 'live' || getObservedChatMode(getChatHost(iframe)) === 'live'
+  return hasLivePath(srcHref)
 }
 
 export const getIframeVideoId = (iframe: HTMLIFrameElement) => {

--- a/entrypoints/content/diagnostics/sanitizeDiagnosticReport.spec.ts
+++ b/entrypoints/content/diagnostics/sanitizeDiagnosticReport.spec.ts
@@ -1,8 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import type { PageEvidence } from '../platform/youtube/types'
-import { createSanitizedDiagnosticReport } from './sanitizeDiagnosticReport'
+import { createSanitizedDiagnosticReport, detectBrowserFamily } from './sanitizeDiagnosticReport'
 
 describe('createSanitizedDiagnosticReport', () => {
+  it('identifies Opera before its shared Chrome product token', () => {
+    expect(
+      detectBrowserFamily(
+        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/149.0.0.0 Safari/537.36 OPR/134.0.0.0',
+      ),
+    ).toBe('opera')
+  })
+
   it('omits page identity and DOM data from exported diagnostics', () => {
     const evidence: PageEvidence = {
       generation: 2,

--- a/entrypoints/content/diagnostics/sanitizeDiagnosticReport.ts
+++ b/entrypoints/content/diagnostics/sanitizeDiagnosticReport.ts
@@ -5,7 +5,7 @@ import { assessCompatibilityFingerprint, buildCompatibilityFingerprint, type Com
 import type { RuntimeFailureCode } from './failureCodes'
 import type { DiagnosticEvent } from './RuntimeTrace'
 
-export type BrowserFamily = 'chrome' | 'firefox' | 'other'
+export type BrowserFamily = 'chrome' | 'firefox' | 'opera' | 'other'
 
 export type SanitizedDiagnosticReport = {
   schemaVersion: 1
@@ -33,6 +33,7 @@ export type SanitizedDiagnosticReport = {
 
 export const detectBrowserFamily = (userAgent: string): BrowserFamily => {
   const normalized = userAgent.toLowerCase()
+  if (normalized.includes('opr/')) return 'opera'
   if (normalized.includes('firefox')) return 'firefox'
   if (normalized.includes('chrome') || normalized.includes('chromium')) return 'chrome'
   return 'other'

--- a/entrypoints/content/features/YTDLiveChatIframe/utils/iframeAttachment.spec.ts
+++ b/entrypoints/content/features/YTDLiveChatIframe/utils/iframeAttachment.spec.ts
@@ -593,6 +593,31 @@ describe('iframeAttachment', () => {
     expect(rebuiltHost.contains(iframe)).toBe(true)
   })
 
+  it('abandons a queued restore without retaining its detached iframe or placeholder', () => {
+    const container = document.createElement('div') as HTMLDivElement
+    const originalParent = document.createElement('div')
+    const originalHost = document.createElement('ytd-live-chat-frame')
+    const iframe = document.createElement('iframe') as HTMLIFrameElement
+
+    originalHost.appendChild(iframe)
+    originalParent.appendChild(originalHost)
+    document.body.append(originalParent, container)
+
+    const attachment = attachIframeToContainer(container, iframe)
+    originalParent.remove()
+    detachAttachedIframe(iframe, container)
+
+    expect(attachment?.state).toBe('restoring')
+    expect(originalHost.childNodes).toHaveLength(1)
+
+    attachment?.abandonRestore()
+    attachment?.abandonRestore()
+
+    expect(attachment?.state).toBe('released')
+    expect(iframe.isConnected).toBe(false)
+    expect(originalHost.childNodes).toHaveLength(0)
+  })
+
   it('does not restore a borrowed iframe into a host for another video', () => {
     const container = document.createElement('div') as HTMLDivElement
     const originalParent = document.createElement('div')

--- a/entrypoints/content/features/YTDLiveChatIframe/utils/iframeAttachment.ts
+++ b/entrypoints/content/features/YTDLiveChatIframe/utils/iframeAttachment.ts
@@ -73,6 +73,7 @@ export type IframeAttachment = {
   captureDocumentStyle(): boolean
   release(options?: { ensureNativeVisible?: boolean }, targets?: PageTargets | null): void
   reconcile(targets?: PageTargets | null): void
+  abandonRestore(): void
 }
 
 const legacyChatOnlyHeightVariables = [
@@ -343,6 +344,10 @@ export const createIframeAttachment = (iframe: HTMLIFrameElement, videoId: strin
     reconcile(targets) {
       if (state !== 'restoring') return
       restoreToAvailableTarget(targets)
+    },
+    abandonRestore() {
+      if (state !== 'restoring') return
+      discardBorrowed()
     },
   }
 }

--- a/entrypoints/content/runtime/ChatRuntime.spec.ts
+++ b/entrypoints/content/runtime/ChatRuntime.spec.ts
@@ -96,6 +96,10 @@ const createLease = (iframe: HTMLIFrameElement, videoId = 'video-1'): ChatIframe
       released = true
       iframe.remove()
     }),
+    abandonRestore: vi.fn(() => {
+      released = true
+      iframe.remove()
+    }),
   }
 }
 
@@ -184,6 +188,24 @@ describe('ChatRuntime', () => {
       removedNodes: [],
     } as unknown as MutationRecord
     expect(mutationTouchesChatBoundary(boundaryMutation)).toBe(true)
+  })
+
+  it('reobserves a native chat iframe when it finishes loading before fullscreen', () => {
+    const harness = createHarness({
+      decisions: [{ kind: 'inactive', reason: 'not-fullscreen' }],
+      snapshots: [createSnapshot({ isFullscreen: false })],
+    })
+    flushFrame()
+    expect(harness.readSnapshot).toHaveBeenCalledTimes(1)
+
+    const iframe = document.createElement('iframe')
+    iframe.id = 'chatframe'
+    document.body.appendChild(iframe)
+    iframe.dispatchEvent(new Event('load'))
+    flushFrame()
+
+    expect(harness.readSnapshot).toHaveBeenCalledTimes(2)
+    harness.runtime.stop()
   })
 
   it('keeps the same iframe lease through a temporary source loss', () => {

--- a/entrypoints/content/runtime/ChatRuntime.ts
+++ b/entrypoints/content/runtime/ChatRuntime.ts
@@ -133,6 +133,8 @@ export class ChatRuntimeImpl implements ChatRuntime {
     this.contentScope = createSessionScope(0)
     this.contentScope.listen(document, 'fullscreenchange', this.handlePageSignal)
     this.contentScope.listen(document, 'yt-navigate-finish', this.handleNavigation)
+    document.addEventListener('load', this.handleResourceLoad, true)
+    this.contentScope.addCleanup(() => document.removeEventListener('load', this.handleResourceLoad, true))
     this.scheduleReconcile()
   }
 
@@ -212,6 +214,13 @@ export class ChatRuntimeImpl implements ChatRuntime {
   }
 
   private handlePageSignal = () => {
+    this.scheduleReconcile()
+  }
+
+  private handleResourceLoad = (event: Event) => {
+    const target = event.target
+    if (!(target instanceof HTMLIFrameElement)) return
+    if (target.id !== 'chatframe' && !target.matches('ytd-live-chat-frame iframe.ytd-live-chat-frame')) return
     this.scheduleReconcile()
   }
 

--- a/entrypoints/content/runtime/ResourceReconciler.spec.ts
+++ b/entrypoints/content/runtime/ResourceReconciler.spec.ts
@@ -68,6 +68,10 @@ const createFakeLease = (log: string[], iframe = document.createElement('iframe'
       state = 'released'
       log.push('iframe-release')
     }),
+    abandonRestore: vi.fn(() => {
+      state = 'released'
+      log.push('iframe-abandoned')
+    }),
   }
   return { lease, setState: (next: ChatIframeLease['state']) => (state = next) }
 }
@@ -207,5 +211,45 @@ describe('ResourceReconciler', () => {
 
     expect(fake.lease.reconcile).toHaveBeenCalledTimes(1)
     expect(log).toEqual(['iframe-release', 'iframe-restored'])
+  })
+
+  it('disposes an unrestorable iframe when runtime monitoring stops', () => {
+    const log: string[] = []
+    const fake = createFakeLease(log)
+    vi.mocked(fake.lease.release).mockImplementation(() => {
+      fake.setState('restoring')
+      log.push('iframe-release')
+    })
+    const resources = new ResourceReconciler({
+      presentation: { sync: vi.fn(() => ({ overlayRoot: null, switchContainer: null })), clear: vi.fn() },
+      chatChrome: { sync: vi.fn(), release: vi.fn() },
+      createLease: () => fake.lease,
+    })
+    const observation = createObservation()
+    resources.createIframe(
+      {
+        kind: 'available',
+        videoId: 'video-1',
+        mode: 'live',
+        source: { kind: 'live_borrow', videoId: 'video-1', iframe: fake.lease.iframe },
+      },
+      1,
+    )
+
+    resources.reconcilePlan(
+      {
+        monitoring: 'inactive',
+        presentation: 'none',
+        chat: { kind: 'none', ensureNativeVisible: false },
+        layout: 'none',
+        retry: { kind: 'none' },
+      },
+      observation,
+      null,
+      vi.fn(),
+    )
+
+    expect(fake.lease.abandonRestore).toHaveBeenCalledOnce()
+    expect(resources.getDiagnosticSnapshot().restoringChatCount).toBe(0)
   })
 })

--- a/entrypoints/content/runtime/ResourceReconciler.ts
+++ b/entrypoints/content/runtime/ResourceReconciler.ts
@@ -78,6 +78,7 @@ export class ResourceReconciler {
 
     if (plan.chat.kind === 'none') this.releaseIframe(pageTargets, plan.chat.ensureNativeVisible)
     if (plan.chat.kind === 'acquire' && !this.sourceMatches(plan.chat.decision)) this.releaseIframe(pageTargets)
+    if (plan.monitoring === 'inactive') this.abandonRestoring()
 
     if (plan.layout === 'none') {
       this.layoutState = 'none'
@@ -190,6 +191,7 @@ export class ResourceReconciler {
   clear(targets: PageTargets | null = null) {
     // Restore the borrowed iframe before removing layout/presentation targets.
     this.releaseIframe(targets)
+    this.abandonRestoring()
     this.layoutLease?.release()
     this.layoutLease = null
     this.layoutScope = null
@@ -198,6 +200,11 @@ export class ResourceReconciler {
     this.presentationState = 'none'
     this.layoutState = 'none'
     this.chatChrome.release()
+  }
+
+  private abandonRestoring() {
+    for (const lease of this.restoringLeases) lease.abandonRestore()
+    this.restoringLeases.clear()
   }
 
   private ensureLayoutLease(scope: SessionScope) {

--- a/entrypoints/content/runtime/resolveChatDecision.spec.ts
+++ b/entrypoints/content/runtime/resolveChatDecision.spec.ts
@@ -173,6 +173,34 @@ describe('resolveChatDecision', () => {
     })
   })
 
+  it('keeps the switch available while an observed Opera replay iframe is temporarily blank', () => {
+    const iframe = element<HTMLIFrameElement>()
+    expect(
+      decide(
+        createSnapshot({
+          chatIframe: iframe,
+          nativeChatIframe: iframe,
+          iframeMode: 'archive',
+          archiveOpenControlAvailable: false,
+        }),
+      ),
+    ).toEqual({
+      kind: 'pending',
+      videoId: 'video-1',
+      mode: 'archive',
+      canToggle: true,
+    })
+  })
+
+  it('keeps the switch unavailable when an archive has neither an observed iframe nor an open control', () => {
+    expect(decide(createSnapshot({ iframeMode: 'archive' }))).toEqual({
+      kind: 'pending',
+      videoId: 'video-1',
+      mode: 'archive',
+      canToggle: false,
+    })
+  })
+
   it('borrows the playable archive iframe without creating a managed replay', () => {
     const iframe = element<HTMLIFrameElement>()
     expect(

--- a/entrypoints/content/runtime/resolveChatDecision.ts
+++ b/entrypoints/content/runtime/resolveChatDecision.ts
@@ -41,7 +41,7 @@ export const resolveChatDecision = (evidence: PageEvidence, targets: PageTargets
         kind: 'pending',
         videoId: evidence.videoId,
         mode: 'archive',
-        canToggle: evidence.capabilities.canOpenArchiveChat,
+        canToggle: targets.chatIframe !== null || evidence.capabilities.canOpenArchiveChat,
       }
     }
     return {

--- a/entrypoints/content/runtime/resources/ChatIframeLease.ts
+++ b/entrypoints/content/runtime/resources/ChatIframeLease.ts
@@ -17,6 +17,7 @@ export type ChatIframeLease = {
   captureDocumentStyle(): boolean
   reconcile(targets?: PageTargets | null): void
   release(options?: { ensureNativeVisible?: boolean }, targets?: PageTargets | null): void
+  abandonRestore(): void
 }
 
 const createLease = (iframe: HTMLIFrameElement, videoId: string, kind: ChatIframeLease['kind'], generation: number): ChatIframeLease => {
@@ -34,6 +35,7 @@ const createLease = (iframe: HTMLIFrameElement, videoId: string, kind: ChatIfram
     captureDocumentStyle: () => attachment.captureDocumentStyle(),
     reconcile: targets => attachment.reconcile(targets),
     release: (options, targets) => attachment.release(options, targets),
+    abandonRestore: () => attachment.abandonRestore(),
   }
 }
 

--- a/entrypoints/settings/RuntimeDiagnosticsPanel.spec.tsx
+++ b/entrypoints/settings/RuntimeDiagnosticsPanel.spec.tsx
@@ -9,7 +9,7 @@ import { RuntimeDiagnosticsPanel } from './RuntimeDiagnosticsPanel'
 const report: SanitizedDiagnosticReport = {
   schemaVersion: 1,
   extensionVersion: '2.3.14',
-  browserFamily: 'chrome',
+  browserFamily: 'opera',
   page: {
     mode: 'live',
     fullscreen: true,
@@ -57,6 +57,7 @@ describe('RuntimeDiagnosticsPanel', () => {
     const { getByRole, getByText } = renderWithStore(<RuntimeDiagnosticsPanel report={report} onRestart={onRestart} />, store)
 
     expect(getByText('正常')).toBeInTheDocument()
+    expect(getByText('opera · live · active · borrowed-live')).toBeInTheDocument()
     fireEvent.click(getByRole('button', { name: 'Runtimeを再起動' }))
     expect(onRestart).toHaveBeenCalledOnce()
   })

--- a/entrypoints/settings/RuntimeDiagnosticsPanel.tsx
+++ b/entrypoints/settings/RuntimeDiagnosticsPanel.tsx
@@ -50,7 +50,9 @@ export const RuntimeDiagnosticsPanel = ({ report, onRestart }: RuntimeDiagnostic
         : text.failed
   const lastRecovery = report?.events.findLast(event => event.event === 'recovered')
   const detail = report
-    ? [report.page.mode, report.runtime.status, report.runtime.leases.chat.kind].filter(value => value !== 'none').join(' · ')
+    ? [report.browserFamily, report.page.mode, report.runtime.status, report.runtime.leases.chat.kind]
+        .filter(value => value !== 'none')
+        .join(' · ')
     : ''
 
   const copyReport = async () => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "youtube-live-chat-fullscreen",
   "private": true,
-  "version": "2.3.14",
+  "version": "2.3.15",
   "type": "module",
   "scripts": {
     "dev": "wxt --host localhost",


### PR DESCRIPTION
## Summary
- harden native chat iframe discovery and restore behavior for Opera
- preserve archive identity when Opera temporarily blanks or replaces the replay iframe
- avoid retaining a blank live iframe, fixing the live-chat handoff regression caught by strict canary
- add regression coverage, Opera fixture support, diagnostics/docs updates
- bump the extension version to 2.3.15

## Root cause
The Opera workaround recorded both archive and live iframe modes. When YouTube blanked a live iframe during handoff, the recorded live mode kept the retired `about:blank` frame eligible. Archive mode needs this fallback on Opera, but live mode must require a current live-chat URL.

## Verification
- `yarn check`
- `yarn test:coverage` — 83 files, 465 tests
- `yarn test:contracts` — 13 files, 62 tests
- `yarn test:package` — Chrome/Firefox production artifacts and contracts
- fixture/visual/accessibility — 19/19
- production Chrome smoke — 1/1
- strict real-YouTube canary — 5/5, no retries/skips
- pinned live regression — 2/2
- Opera 134 fixture E2E — 12/12
- Opera 134 real YouTube archive fullscreen chat — rendered
- Google Chrome 151 real YouTube archive fullscreen chat — rendered
- Firefox 153 real YouTube archive fullscreen chat — rendered
