### PR TITLE
Bound fullscreen canary interactions

### DIFF
--- a/e2e/pages/YouTubeWatchPage.ts
+++ b/e2e/pages/YouTubeWatchPage.ts
@@ -1,13 +1,13 @@
-import { expect, type Page } from '@playwright/test'
 import { TIMEOUT } from '@e2e/support/constants'
 import { acceptYouTubeConsentWithRetry } from '@e2e/utils/liveUrl'
 import { FULLSCREEN_BUTTON, MOVIE_PLAYER, NATIVE_CHAT_FRAME } from '@e2e/utils/selectors'
+import { expect, type Page } from '@playwright/test'
 
 export class YouTubeWatchPage {
   constructor(private page: Page) {}
 
-  private async revealPlayerControls() {
-    await this.page.locator(MOVIE_PLAYER).hover({ force: true, timeout: 5000 })
+  private async revealPlayerControls(timeout: number) {
+    await this.page.locator(MOVIE_PLAYER).hover({ force: true, timeout: Math.min(timeout, 5000) })
   }
 
   async goto(url: string, options?: { timeout?: number }) {
@@ -19,16 +19,24 @@ export class YouTubeWatchPage {
 
   async enterFullscreen(options?: { timeout?: number }) {
     const timeout = options?.timeout ?? TIMEOUT.FULLSCREEN
-    await this.revealPlayerControls()
-    await this.page.click(FULLSCREEN_BUTTON)
-    await this.page.waitForFunction(() => document.fullscreenElement !== null, undefined, { timeout })
+    const deadline = Date.now() + timeout
+    const remainingTimeout = () => Math.max(1, deadline - Date.now())
+
+    await this.revealPlayerControls(remainingTimeout())
+    await this.page.click(FULLSCREEN_BUTTON, { timeout: remainingTimeout() })
+    await this.page.waitForFunction(() => document.fullscreenElement !== null, undefined, {
+      timeout: remainingTimeout(),
+    })
   }
 
   async expectFullscreenExited(options?: { timeout?: number }): Promise<void> {
     const timeout = options?.timeout ?? TIMEOUT.FULLSCREEN
-    await this.revealPlayerControls()
-    await this.page.click(FULLSCREEN_BUTTON)
-    await expect.poll(async () => this.isInFullscreen(), { timeout }).toBe(false)
+    const deadline = Date.now() + timeout
+    const remainingTimeout = () => Math.max(1, deadline - Date.now())
+
+    await this.revealPlayerControls(remainingTimeout())
+    await this.page.click(FULLSCREEN_BUTTON, { timeout: remainingTimeout() })
+    await expect.poll(async () => this.isInFullscreen(), { timeout: remainingTimeout() }).toBe(false)
   }
 
   async expectNativeChat(options?: { timeout?: number }): Promise<void> {

--- a/e2e/pages/YouTubeWatchPage.unit.spec.ts
+++ b/e2e/pages/YouTubeWatchPage.unit.spec.ts
@@ -1,0 +1,39 @@
+import type { Page } from '@playwright/test'
+import { describe, expect, it, vi } from 'vitest'
+import { YouTubeWatchPage } from './YouTubeWatchPage'
+
+describe('YouTubeWatchPage', () => {
+  it('bounds every fullscreen UI action by the requested timeout', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000)
+    const hover = vi.fn().mockResolvedValue(undefined)
+    const click = vi.fn().mockResolvedValue(undefined)
+    const waitForFunction = vi.fn().mockResolvedValue(undefined)
+    const page = {
+      locator: vi.fn(() => ({ hover })),
+      click,
+      waitForFunction,
+    } as unknown as Page
+
+    await new YouTubeWatchPage(page).enterFullscreen({ timeout: 8000 })
+
+    expect(hover).toHaveBeenCalledWith({ force: true, timeout: 5000 })
+    expect(click).toHaveBeenCalledWith('button.ytp-fullscreen-button', { timeout: 8000 })
+    expect(waitForFunction).toHaveBeenCalledWith(expect.any(Function), undefined, { timeout: 8000 })
+  })
+
+  it('bounds the fullscreen exit click by the requested timeout', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(1000)
+    const hover = vi.fn().mockResolvedValue(undefined)
+    const click = vi.fn().mockResolvedValue(undefined)
+    const page = {
+      locator: vi.fn(() => ({ hover })),
+      click,
+      evaluate: vi.fn().mockResolvedValue(false),
+    } as unknown as Page
+
+    await new YouTubeWatchPage(page).expectFullscreenExited({ timeout: 8000 })
+
+    expect(hover).toHaveBeenCalledWith({ force: true, timeout: 5000 })
+    expect(click).toHaveBeenCalledWith('button.ytp-fullscreen-button', { timeout: 8000 })
+  })
+})


### PR DESCRIPTION
## Summary
- apply the configured fullscreen timeout to hover, click, and fullscreen state checks
- prevent a YouTube anti-bot/player block from consuming the entire canary test timeout
- add regression coverage for fullscreen enter and exit interactions

## Verification
- `yarn check`
- `yarn test:coverage` (84 files, 466 tests; coverage contract 3 tests)
- `yarn test:contracts` (13 files, 62 tests)
- `yarn test:package` (Chrome/Firefox package contracts)
- exact production Chrome ZIP smoke (1/1)
- strict real-YouTube canary (5/5, no retries/skips)
- fixture/visual/accessibility browser contracts (19/19)