### PR TITLE
Fix live canary search filter

### DIFF
--- a/e2e/config/testTargets.spec.ts
+++ b/e2e/config/testTargets.spec.ts
@@ -33,10 +33,11 @@ describe('getE2ETestTargets', () => {
     expect(targets.noChat.url).toContain('/watch?v=')
     expect(targets.live.preferredUrl).toBeNull()
     expect(targets.liveSearch.urls).toEqual([
-      'https://www.youtube.com/results?search_query=vtuber&sp=EgJAAQ%253D%253D',
-      'https://www.youtube.com/results?search_query=%E3%82%B2%E3%83%BC%E3%83%A0%E9%85%8D%E4%BF%A1&sp=EgJAAQ%253D%253D',
-      'https://www.youtube.com/results?search_query=live+stream+chat&sp=EgJAAQ%253D%253D',
+      'https://www.youtube.com/results?search_query=vtuber&sp=EgJAAQ%3D%3D',
+      'https://www.youtube.com/results?search_query=%E3%82%B2%E3%83%BC%E3%83%A0%E9%85%8D%E4%BF%A1&sp=EgJAAQ%3D%3D',
+      'https://www.youtube.com/results?search_query=live+stream+chat&sp=EgJAAQ%3D%3D',
     ])
+    expect(targets.liveSearch.urls.every(url => new URL(url).searchParams.get('sp') === 'EgJAAQ==')).toBe(true)
   })
 
   it('uses existing YLC_* env overrides', () => {

--- a/e2e/config/testTargets.ts
+++ b/e2e/config/testTargets.ts
@@ -28,9 +28,9 @@ const DEFAULT_ARCHIVE_TRANSITION_FROM_URL = 'https://www.youtube.com/watch?v=xyi
 const DEFAULT_ARCHIVE_TRANSITION_TO_URL = 'https://www.youtube.com/watch?v=akIQbHSh_oU&list=PLFZAmR0gqBTIoMCCUfEaKER4m6I98GrWj&index=2'
 const DEFAULT_NO_CHAT_URL = 'https://www.youtube.com/watch?v=jNQXAC9IVRw'
 const DEFAULT_LIVE_SEARCH_URLS = [
-  'https://www.youtube.com/results?search_query=vtuber&sp=EgJAAQ%253D%253D',
-  'https://www.youtube.com/results?search_query=%E3%82%B2%E3%83%BC%E3%83%A0%E9%85%8D%E4%BF%A1&sp=EgJAAQ%253D%253D',
-  'https://www.youtube.com/results?search_query=live+stream+chat&sp=EgJAAQ%253D%253D',
+  'https://www.youtube.com/results?search_query=vtuber&sp=EgJAAQ%3D%3D',
+  'https://www.youtube.com/results?search_query=%E3%82%B2%E3%83%BC%E3%83%A0%E9%85%8D%E4%BF%A1&sp=EgJAAQ%3D%3D',
+  'https://www.youtube.com/results?search_query=live+stream+chat&sp=EgJAAQ%3D%3D',
 ]
 
 const normalizeEnv = (value: string | undefined) => {


### PR DESCRIPTION
## Summary
- stop double-encoding YouTube's live-only search filter
- make live canary discovery return actual live results instead of ordinary videos
- assert the decoded filter token in the target contract

## Evidence
Two release-candidate attempts inspected 16–20 ordinary candidates and ended with all 5 canaries skipped. With the corrected filter, the first candidate was playable and the strict canary passed 5/5 in 1 minute.

## Verification
- `yarn check`
- `yarn test:coverage` (84 files, 467 tests; coverage contract 3 tests)
- `yarn test:contracts` (13 files, 62 tests)
- focused target contract (3/3)
- strict real-YouTube canary against exact 2.3.15 Chrome ZIP (5/5, no retries/skips)