### PR TITLE
Separate hosted and real-browser release evidence

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,6 +2,16 @@ name: Release candidate
 
 on:
   workflow_dispatch:
+    inputs:
+      real_browser_verified:
+        description: Confirm Chrome, Firefox, and Opera were verified on real YouTube with this version
+        required: true
+        type: boolean
+        default: false
+      real_browser_evidence:
+        description: Browser versions and verified YouTube scenario
+        required: true
+        type: string
 
 concurrency:
   group: release-candidate-${{ github.ref }}
@@ -32,12 +42,19 @@ jobs:
             echo "Release candidates must run from main, got: $GITHUB_REF"
             exit 1
           fi
+          if [[ "$REAL_BROWSER_VERIFIED" != "true" || ${#REAL_BROWSER_EVIDENCE} -lt 20 ]]; then
+            echo "Release candidates require a concrete real-browser verification attestation."
+            exit 1
+          fi
           VERSION=$(node -p "require('./package.json').version")
           if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?(\+[0-9A-Za-z]+([.-][0-9A-Za-z]+)*)?$ ]]; then
             echo "Invalid version in package.json: $VERSION"
             exit 1
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        env:
+          REAL_BROWSER_VERIFIED: ${{ inputs.real_browser_verified }}
+          REAL_BROWSER_EVIDENCE: ${{ inputs.real_browser_evidence }}
       - name: Install dependencies
         run: yarn install --immutable
       - name: Check generated locales
@@ -64,14 +81,30 @@ jobs:
         run: xvfb-run --auto-servernum yarn playwright test --project=fixture --project=visual --project=accessibility --retries=0 --max-failures=1
       - name: Smoke exact production Chrome ZIP
         run: xvfb-run --auto-servernum yarn e2e:production:chrome
-      - name: Run strict canary against the exact production Chrome ZIP
+      - name: Run hosted real-YouTube canary against the exact production Chrome ZIP
+        id: canary
         env:
           YLC_EXTENSION_OUTPUT_DIR: .output/production-smoke/chrome
           YLC_REQUIRE_E2E_BRIDGE: "0"
-          YLC_CANARY_REQUIRE_CLEAN: "1"
-        run: xvfb-run --auto-servernum yarn playwright test --project=canary --retries=0 --max-failures=1
+          YLC_CANARY_SUMMARY_PATH: test-results/release-canary-summary.json
+        shell: bash
+        run: |
+          set +e
+          xvfb-run --auto-servernum yarn playwright test --project=canary --retries=0 --max-failures=1
+          CANARY_EXIT=$?
+          set -e
+          CANARY_STATUS=$(node scripts/verify/classify-release-canary.mjs "$YLC_CANARY_SUMMARY_PATH" "$CANARY_EXIT")
+          echo "status=$CANARY_STATUS" >> "$GITHUB_OUTPUT"
       - name: Create release proof
-        run: node scripts/verify/release-proof.mjs create --commit "$GITHUB_SHA"
+        env:
+          GITHUB_CANARY_STATUS: ${{ steps.canary.outputs.status }}
+          REAL_BROWSER_ACTOR: ${{ github.actor }}
+          REAL_BROWSER_EVIDENCE: ${{ inputs.real_browser_evidence }}
+        run: >-
+          node scripts/verify/release-proof.mjs create --commit "$GITHUB_SHA"
+          --github-canary-status "$GITHUB_CANARY_STATUS"
+          --real-browser-actor "$REAL_BROWSER_ACTOR"
+          --real-browser-evidence "$REAL_BROWSER_EVIDENCE"
       - name: Upload browser diagnostics
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/e2e/reporters/canarySummary.ts
+++ b/e2e/reporters/canarySummary.ts
@@ -1,4 +1,5 @@
-import { appendFile } from 'node:fs/promises'
+import { appendFile, mkdir, writeFile } from 'node:fs/promises'
+import path from 'node:path'
 import type { FullResult, Reporter, Suite } from '@playwright/test/reporter'
 import { CANARY_PROJECT_NAME } from '../config/projectClassification'
 
@@ -106,6 +107,11 @@ class CanarySummaryReporter implements Reporter {
     const summary = summarizeCanaryOutcomes(outcomes, result.status)
     const summaryPath = process.env.GITHUB_STEP_SUMMARY
     if (summaryPath) await appendFile(summaryPath, `\n${renderCanarySummary(outcomes, result.status)}\n`, 'utf8')
+    const jsonPath = process.env.YLC_CANARY_SUMMARY_PATH
+    if (jsonPath) {
+      await mkdir(path.dirname(jsonPath), { recursive: true })
+      await writeFile(jsonPath, `${JSON.stringify({ summary, outcomes, runStatus: result.status }, null, 2)}\n`, 'utf8')
+    }
     if (shouldFailCanaryRun(summary, process.env.YLC_CANARY_REQUIRE_CLEAN === '1')) return { status: 'failed' as const }
   }
 

--- a/scripts/verify/check-release-workflow.mjs
+++ b/scripts/verify/check-release-workflow.mjs
@@ -9,6 +9,8 @@ const publishTrigger = publish.slice(publish.indexOf('on:'), publish.indexOf('co
 
 assert.doesNotMatch(candidateTrigger, /^  push:$/m, 'Merging main must not publish a new version')
 assert.match(candidateTrigger, /^  workflow_dispatch:$/m, 'Candidate creation must be an intentional manual action')
+assert.match(candidateTrigger, /^      real_browser_verified:$/m, 'Candidate creation must require real-browser confirmation')
+assert.match(candidateTrigger, /^      real_browser_evidence:$/m, 'Candidate creation must record concrete real-browser evidence')
 assert.match(publishTrigger, /^  workflow_dispatch:$/m, 'Store publication must be an intentional manual action')
 assert.match(publishTrigger, /^      version:$/m, 'Publication must select an existing candidate version')
 
@@ -19,7 +21,9 @@ assert.match(candidate, /run: yarn verify:package-contracts/, 'Candidate workflo
 assert.match(candidate, /--project=fixture --project=visual --project=accessibility --retries=0/, 'Deterministic gates must run without retries')
 assert.match(candidate, /run: xvfb-run --auto-servernum yarn e2e:production:chrome/, 'The exact Chrome ZIP must boot before attestation')
 assert.match(candidate, /YLC_EXTENSION_OUTPUT_DIR: \.output\/production-smoke\/chrome/, 'The canary must use the extracted production ZIP')
-assert.match(candidate, /YLC_CANARY_REQUIRE_CLEAN: "1"/, 'A degraded or skipped canary must reject a release candidate')
+assert.match(candidate, /YLC_CANARY_SUMMARY_PATH: test-results\/release-canary-summary\.json/, 'The hosted canary must emit a machine-readable result')
+assert.match(candidate, /classify-release-canary\.mjs/, 'The hosted canary must distinguish external unavailability from product failures')
+assert.match(candidate, /--real-browser-evidence "\$REAL_BROWSER_EVIDENCE"/, 'Candidate proof must include real-browser evidence')
 assert.match(candidate, /release-proof\.mjs create --commit "\$GITHUB_SHA"/, 'Candidate hashes and commit must be attested')
 assert.match(candidate, /release-proof-v\$\{\{ steps\.version\.outputs\.version \}\}\.json/, 'Release proof must travel with package assets')
 assert.match(candidate, /gh release create .* --draft /, 'Verified candidates must remain draft releases')

--- a/scripts/verify/classify-release-canary.mjs
+++ b/scripts/verify/classify-release-canary.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { readFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+
+export const classifyReleaseCanary = (payload, exitCode) => {
+  const summary = payload?.summary
+  if (!summary || !Number.isInteger(exitCode)) throw new Error('Canary summary or exit code is invalid.')
+
+  if (exitCode === 0 && summary.state === 'passed' && summary.executed > 0 && summary.failed === 0 && summary.skipped === 0) {
+    return 'passed'
+  }
+
+  if (summary.state === 'not-run' && summary.executed === 0 && summary.failed === 0 && summary.skipped > 0) {
+    return 'unavailable'
+  }
+
+  throw new Error(
+    `Release canary is neither clean nor externally unavailable: state=${summary.state}, executed=${summary.executed}, failed=${summary.failed}, skipped=${summary.skipped}, exit=${exitCode}`,
+  )
+}
+
+const isDirectInvocation = process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url
+if (isDirectInvocation) {
+  const [summaryPath, rawExitCode] = process.argv.slice(2)
+  if (!summaryPath || rawExitCode === undefined) {
+    throw new Error('Usage: classify-release-canary.mjs <summary.json> <playwright-exit-code>')
+  }
+  const payload = JSON.parse(await readFile(summaryPath, 'utf8'))
+  console.log(classifyReleaseCanary(payload, Number(rawExitCode)))
+}

--- a/scripts/verify/classify-release-canary.spec.mjs
+++ b/scripts/verify/classify-release-canary.spec.mjs
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { classifyReleaseCanary } from './classify-release-canary.mjs'
+
+const payload = summary => ({ summary })
+
+describe('classifyReleaseCanary', () => {
+  it('accepts only a clean, executed canary as passed', () => {
+    expect(classifyReleaseCanary(payload({ state: 'passed', executed: 5, passed: 5, flaky: 0, skipped: 0, failed: 0 }), 0)).toBe('passed')
+  })
+
+  it('classifies an all-skipped run as externally unavailable', () => {
+    expect(classifyReleaseCanary(payload({ state: 'not-run', executed: 0, passed: 0, flaky: 0, skipped: 5, failed: 0 }), 1)).toBe(
+      'unavailable',
+    )
+  })
+
+  it.each([
+    [{ state: 'degraded', executed: 4, passed: 4, flaky: 0, skipped: 1, failed: 0 }, 0],
+    [{ state: 'failed', executed: 5, passed: 4, flaky: 0, skipped: 0, failed: 1 }, 1],
+    [{ state: 'passed', executed: 5, passed: 5, flaky: 0, skipped: 0, failed: 0 }, 1],
+  ])('rejects partial or product-owned failures', (summary, exitCode) => {
+    expect(() => classifyReleaseCanary(payload(summary), exitCode)).toThrow('neither clean nor externally unavailable')
+  })
+})

--- a/scripts/verify/release-proof.mjs
+++ b/scripts/verify/release-proof.mjs
@@ -36,16 +36,32 @@ if (command === 'create') {
   const commit = requireCommit(
     readOption('--commit') ?? execFileSync('git', ['rev-parse', 'HEAD'], { cwd: root, encoding: 'utf8' }).trim(),
   )
+  const githubCanaryStatus = readOption('--github-canary-status')
+  if (!['passed', 'unavailable'].includes(githubCanaryStatus)) {
+    throw new Error(`Release proof requires a valid GitHub canary status, got: ${githubCanaryStatus}`)
+  }
+  const realBrowserActor = readOption('--real-browser-actor')
+  const realBrowserEvidence = readOption('--real-browser-evidence')
+  if (!realBrowserActor || !realBrowserEvidence || realBrowserEvidence.length < 20) {
+    throw new Error('Release proof requires concrete real-browser verification evidence.')
+  }
   const proof = {
-    schemaVersion: 1,
+    schemaVersion: 2,
     version,
     commit,
     createdAt: new Date().toISOString(),
     browserEvidence: {
-      engine: 'chromium',
-      runner: 'ubuntu-24.04',
-      playwright: packageJson.devDependencies['@playwright/test'],
-      package: 'production-chrome-zip',
+      githubHostedCanary: {
+        engine: 'chromium',
+        runner: 'ubuntu-24.04',
+        playwright: packageJson.devDependencies['@playwright/test'],
+        package: 'production-chrome-zip',
+        status: githubCanaryStatus,
+      },
+      realBrowserAttestation: {
+        actor: realBrowserActor,
+        evidence: realBrowserEvidence,
+      },
     },
     artifacts: await Promise.all(artifactNames.map(describeArtifact)),
     gates: [
@@ -54,7 +70,8 @@ if (command === 'create') {
       { id: 'production-package-contracts', status: 'passed' },
       { id: 'deterministic-browser-contracts', status: 'passed' },
       { id: 'production-chrome-zip-smoke', status: 'passed' },
-      { id: 'real-youtube-canary-clean', status: 'passed' },
+      { id: 'github-hosted-real-youtube-canary', status: githubCanaryStatus },
+      { id: 'real-browser-manual-attestation', status: 'passed' },
     ],
     invariants: [
       'REG-221-video-isolation',
@@ -68,13 +85,16 @@ if (command === 'create') {
   console.log(`Created release proof: ${path.relative(root, proofPath)}`)
 } else if (command === 'verify') {
   const proof = JSON.parse(await readFile(proofPath, 'utf8'))
-  if (proof.schemaVersion !== 1 || proof.version !== version) throw new Error('Release proof schema or version does not match package.json.')
+  if (proof.schemaVersion !== 2 || proof.version !== version) throw new Error('Release proof schema or version does not match package.json.')
   requireCommit(proof.commit)
   if (
-    proof.browserEvidence?.engine !== 'chromium' ||
-    proof.browserEvidence?.runner !== 'ubuntu-24.04' ||
-    proof.browserEvidence?.playwright !== packageJson.devDependencies['@playwright/test'] ||
-    proof.browserEvidence?.package !== 'production-chrome-zip'
+    proof.browserEvidence?.githubHostedCanary?.engine !== 'chromium' ||
+    proof.browserEvidence?.githubHostedCanary?.runner !== 'ubuntu-24.04' ||
+    proof.browserEvidence?.githubHostedCanary?.playwright !== packageJson.devDependencies['@playwright/test'] ||
+    proof.browserEvidence?.githubHostedCanary?.package !== 'production-chrome-zip' ||
+    !['passed', 'unavailable'].includes(proof.browserEvidence?.githubHostedCanary?.status) ||
+    !proof.browserEvidence?.realBrowserAttestation?.actor ||
+    !proof.browserEvidence?.realBrowserAttestation?.evidence
   ) {
     throw new Error('Release proof browser identity is missing or does not match this revision.')
   }
@@ -99,10 +119,14 @@ if (command === 'create') {
     'production-package-contracts',
     'deterministic-browser-contracts',
     'production-chrome-zip-smoke',
-    'real-youtube-canary-clean',
+    'real-browser-manual-attestation',
   ]
   for (const id of requiredGates) {
     if (!proof.gates?.some(gate => gate.id === id && gate.status === 'passed')) throw new Error(`Release gate is not proven: ${id}`)
+  }
+  const hostedCanaryGate = proof.gates?.find(gate => gate.id === 'github-hosted-real-youtube-canary')
+  if (!hostedCanaryGate || hostedCanaryGate.status !== proof.browserEvidence.githubHostedCanary.status) {
+    throw new Error('GitHub-hosted canary evidence does not match its release gate.')
   }
   console.log(`Verified release proof for v${version} at ${proof.commit}`)
 } else {


### PR DESCRIPTION
## Summary
- keep product failures and partial/degraded hosted canaries release-blocking
- classify only an all-skipped hosted run as external `unavailable`
- require and preserve concrete Chrome/Firefox/Opera real-browser evidence in the release proof
- emit a machine-readable canary summary and verify it with focused contract tests

## Why
Three independent GitHub-hosted attempts were blocked by YouTube's bot confirmation and produced 5/5 external skips. Re-running cannot turn the hosted runner into reliable real-browser evidence. This change records that limitation explicitly without weakening product-owned assertions.

## Verification
- exact local and GitHub branch trees match (`175eecf3...`)
- `yarn check`
- `yarn test:coverage` (84 files, 467 tests; coverage contract 3 tests)
- `yarn test:contracts` (14 files, 67 tests)
- classifier/reporter contracts (15 tests)
- release proof create + verify round trip
- machine-readable real-YouTube canary: 5/5 passed; classifier returned `passed`
- prior exact 2.3.15 Chrome ZIP smoke 1/1 and fixture/visual/accessibility 19/19