### PR TITLE
Fix GitHub release promotion

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -125,4 +125,8 @@ jobs:
         env:
           RELEASE_VERSION: ${{ inputs.version }}
           GH_TOKEN: ${{ github.token }}
-        run: gh release edit "v$RELEASE_VERSION" --draft=false --latest
+        run: >-
+          gh release edit "v$RELEASE_VERSION"
+          --repo "$GITHUB_REPOSITORY"
+          --draft=false
+          --latest


### PR DESCRIPTION
## Summary

- pass the repository explicitly to `gh release edit`
- allow the checkout-free final promotion job to publish the proven draft release

## Verification

- `yarn check`
- `node scripts/verify/check-release-workflow.mjs`
- `git diff --check`

This fixes the final failure observed in Publish proven release run 32137976427. Chrome Web Store and Firefox Add-ons submission had already succeeded; the exact v2.3.15 draft was published manually after the failure.